### PR TITLE
ls.socrata in exported namespace; dataset listing example fix

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,7 @@
 export(fieldName)
 export(posixify)
 export(read.socrata)
+export(ls.socrata)
 import(jsonlite)
 import(httr)
 import(mime)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ nrow(earthquakesDataFrame)
 
 ### Example: List all datasets on portal
 ```r
-allSitesDataFrame <- read.socrata("https://soda.demo.socrata.com")
+allSitesDataFrame <- ls.socrata("https://soda.demo.socrata.com")
 nrow(allSitesDataFrame) # Number of datasets
 allSitesDataFrame$title # Names of each dataset
 ```


### PR DESCRIPTION
Don't know how I missed putting ls.socrata into the exported namespace before. I think I was loading from devtools and somehow didn't get an error. Also, noticed that the dataset listing example in the readme was off.