### PR TITLE
Proposed release candidate for v1.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Description: Provided with a Socrata dataset resource URL,
     returns an R data frame.
     Converts dates to POSIX format.
     Manages throttling by Socrata.
-Version: 1.6.0-7
-Date: 2015-2-22
+Version: 1.6.0-8
+Date: 2015-2-23
 URL: https://github.com/Chicago/RSocrata
 BugReports: https://github.com/Chicago/RSocrata/issues
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Provided with a Socrata dataset resource URL,
     returns an R data frame.
     Converts dates to POSIX format.
     Manages throttling by Socrata.
-Version: 1.6.0-8
+Version: 1.6.0-9
 Date: 2015-2-23
 URL: https://github.com/Chicago/RSocrata
 BugReports: https://github.com/Chicago/RSocrata/issues

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -44,6 +44,8 @@ isFourByFour <- function(fourByFour) {
 #' argument or will also accept API token in the URL query. Will
 #' resolve conflicting API token by deferring to original URL.
 #' @param url  a string; character vector of length one
+#' @param app_token a string; SODA API token used to query the data 
+#' portal \url{http://dev.socrata.com/consumers/getting-started.html}
 #' @return a valid Url
 #' @author Tom Schenk Jr \email{tom.schenk@@cityofchicago.org}
 validateUrl <- function(url, app_token) {
@@ -177,6 +179,8 @@ getSodaTypes <- function(response) {
 #' requesting a comma-separated download format (.csv suffix), 
 #' May include SoQL parameters, 
 #' but is assumed to not include a SODA offset parameter
+#' @param app_token a string; SODA API token used to query the data 
+#' portal \url{http://dev.socrata.com/consumers/getting-started.html}
 #' @return an R data frame with POSIX dates
 #' @export
 #' @author Hugh J. Devlin, Ph. D. \email{Hugh.Devlin@@cityofchicago.org}

--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ Please report issues, request enhancements or fork us at the [City of Chicago gi
 * Added unit test for reading private datasets
 
 1.5.1 Deprecated ```httr::guess_media()``` and implemented ```httr::guess_type()```
+
+1.6.0 Several changes:
+* New function, ```ls.socrata``` to list all datasets on a Socrata portal.
+* New optional argument, ```app_token```, which lets users supply an API token while using ```read.socrata() to minimize throttling.
+* Repairs a bug where ```read.socrata``` failed when reading in a date with a column, but there are null values in that column.

--- a/RSocrata.Rproj
+++ b/RSocrata.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran
+PackageRoxygenize: rd


### PR DESCRIPTION
If accepted, this will be the build submitted to CRAN as the first stable version of 1.6.0. This stable version (cumulatively since v1.5.1) includes the following
* Adds a new function, `ls.socrata()` that allows users to download the list of datasets available on the CRAN portal
* Adds a new optional argument, `app_token`, in `read.socrata()` that allows users to supply an API token to minimize throttling.
* Repairs a bug where ```read.socrata``` failed when reading in a date with a column, but there are null values in that column.\

If accepted, this will be submitted to CRAN as version 1.6.0.