### PR TITLE
update travis to a new version, i.e. proper "r" instead of old "c"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ r_github_packages:
   - jeroenooms/curl
   - klutometis/roxygen
 
-after_success: 
+before_install: 
   - Rscript -e "library(roxygen2); roxygen2::roxygenize(package.dir='.', roclets=c('rd', 'collate', 'namespace'))"
+  
+after_success:  
   - Rscript -e 'source("R/tests/testRSocrata.R"); runAllTestsCI()'
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,21 @@
 #
 # See README.md for instructions, or for more configuration options,
 # see the wiki:
-#   https://github.com/craigcitro/r-travis/wiki
+#   http://docs.travis-ci.com/user/languages/r/
 
-language: c
+language: R
+sudo: required
+warnings_are_errors: true
 
-env:
-  - global:
-    - WARNINGS_ARE_ERRORS=1
+r_github_packages:
+  - hadley/httr
+  - jeroenooms/jsonlite
+  - jeroenooms/curl
+  - klutometis/roxygen
 
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-install:
-  - ./travis-tool.sh install_deps
-script: 
-  - Rscript -e "install.packages('roxygen2', repos='http://cran.us.r-project.org'); library(roxygen2); roxygen2::roxygenize(package.dir='.', roclets=c('rd', 'collate', 'namespace'))"
-  - ./travis-tool.sh run_tests
+after_success: 
+  - Rscript -e "library(roxygen2); roxygen2::roxygenize(package.dir='.', roclets=c('rd', 'collate', 'namespace'))"
   - Rscript -e 'source("R/tests/testRSocrata.R"); runAllTestsCI()'
-
-after_failure:
-  - ./travis-tool.sh dump_logs
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ r_github_packages:
   - klutometis/roxygen
 
 before_install: 
-  - Rscript -e "library(roxygen2); roxygen2::roxygenize(package.dir='.', roclets=c('rd', 'collate', 'namespace'))"
+  - Rscript -e "install.packages('roxygen2'); library(roxygen2); roxygen2::roxygenize(package.dir='.', roclets=c('rd', 'collate', 'namespace'))"
   
 after_success:  
   - Rscript -e 'source("R/tests/testRSocrata.R"); runAllTestsCI()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ r_github_packages:
   - klutometis/roxygen
 
 before_install: 
-  - Rscript -e "install.packages('roxygen2'); library(roxygen2); roxygen2::roxygenize(package.dir='.', roclets=c('rd', 'collate', 'namespace'))"
+  - Rscript -e "install.packages('roxygen2', repos='http://cran.us.r-project.org'); library(roxygen2); roxygen2::roxygenize(package.dir='.', roclets=c('rd', 'collate', 'namespace'))"
   
 after_success:  
   - Rscript -e 'source("R/tests/testRSocrata.R"); runAllTestsCI()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,8 @@ Description: Provides easier interaction with
     returns an R data frame.
     Converts dates to 'POSIX' format.
     Manages throttling by 'Socrata'.
-Version: 1.6.1-2
-Date: 2015-6-5
+Version: 1.6.1-3
+Date: 2015-6-7
 URL: https://github.com/Chicago/RSocrata
 BugReports: https://github.com/Chicago/RSocrata/issues
 Imports:


### PR DESCRIPTION
Hi @tomschenkjr, 

This PR updates travis "c" to proper "r" version. In addition, it automatically fetches newest changes from github repos so that you can test against `bleeding edge version` of 4 packages.

LInk to my travis as this passes what it needs to pass:
https://travis-ci.org/dmpe/RSocrata/builds

PS: The test run 10 minutes, because of roxygen2 and its dependencies. However, on almost every ubuntu image (non-travis) it will take FAR less. 

https://travis-ci.org/Chicago/RSocrata/builds/69931842
https://travis-ci.org/dmpe/RSocrata/builds/69934202