### PR TITLE
Fixed version numbering; updated NEWS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-2
-Date: 2016-02-25
+Version: 1.7.1-10
+Date: 2016-03-11
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,10 @@ Bug fixes:
 * Converts a Socrata money field into a proper numeric field, instead of a factor.
 * Updated build method for Travis to test using the current CRAN packages, not beta packages from GitHub.
 
+### 1.7.1 Bug fixes:
 
-
-
+* Users provided an option to handle string-like fields as characters (chr) or factors. Default is to handle string-like fields as character vectors ([#27](https://github.com/Chicago/RSocrata/issues/27))
+* Fixes bug where dates are incorrectly read when first date is a blank ([#68](https://github.com/Chicago/RSocrata/issues/68))
+* Dates are now handled using `POSIXct` instead of `POSIXlt` ([#8](https://github.com/Chicago/RSocrata/issues/8))
+* Added additional unit testing ([#28](https://github.com/Chicago/RSocrata/issues/68))
+* Artifacts from Appveyor CI can now be directly submitted to CRAN ([#77](https://github.com/Chicago/RSocrata/issues/77))


### PR DESCRIPTION
Some clean-up. Version number had skipped from 1.7.1-x to 1.7.2-x. I've reconciled that back to 1.7.1 (since it hasn't been submitted to CRAN). I looked at the commit history and set the version to  1.7.1-10, which reflects the number of commits between 1.7.1 and 1.7.2.

Second, I updated the `NEWS` file to reflect the bug fixes. @geneorama - let me know if I'm missing anything.