### PR TITLE
New stable build for 1.7.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,5 +21,8 @@ When you want to make a change, either to fix a bug or introduce a new feature, 
 * Create a branch or fork of the project based off of the `dev` branch.
 * Make commits of logical units
 * Add unit tests for any new features
+* Iterate either version or build number in the `DESCRIPTION` file:
+  * The version number follows the `x.y.z-build` format and increments based on [semantic versioning 2.0.0](http://semver.org/spec/v2.0.0.html). Please update versions corresponding to those guidelines.
+  * If your contribution takes several commits, please increment the build number (e.g., x.y.z-build) so there is a unique relationship of the version-build number to each commit.
 * Run all tests in `tests/testthat/`
 * Create a pull request with a robust description or [reference the issue number](https://github.com/Chicago/RSocrata/issues)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-7
+Version: 1.7.1-8
 Date: 2016-02-13
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-2
-Date: 2016-02-25
+Version: 1.7.1-10
+Date: 2016-03-11
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,10 @@ Bug fixes:
 * Converts a Socrata money field into a proper numeric field, instead of a factor.
 * Updated build method for Travis to test using the current CRAN packages, not beta packages from GitHub.
 
+### 1.7.1 Bug fixes:
 
-
-
+* Users provided an option to handle string-like fields as characters (chr) or factors. Default is to handle string-like fields as character vectors ([#27](https://github.com/Chicago/RSocrata/issues/27))
+* Fixes bug where dates are incorrectly read when first date is a blank ([#68](https://github.com/Chicago/RSocrata/issues/68))
+* Dates are now handled using `POSIXct` instead of `POSIXlt` ([#8](https://github.com/Chicago/RSocrata/issues/8))
+* Added additional unit testing ([#28](https://github.com/Chicago/RSocrata/issues/68))
+* Artifacts from Appveyor CI can now be directly submitted to CRAN ([#77](https://github.com/Chicago/RSocrata/issues/77))

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -81,6 +81,14 @@ test_that("readSocrataHumanReadable", {
   expect_equal(9, ncol(df), label="columns")
 })
 
+test_that("Read data with missing dates", { # See issue #24 & #27 
+  # Query below will pull Boston's 311 requests from early July 2011. Contains NA dates.
+  df <- read.socrata("https://data.cityofboston.gov/resource/awu8-dc52.csv?$where=case_enquiry_id< 101000295717")
+  expect_equal(99, nrow(df), label="rows")
+  na_time_rows <- df[is.na(df$TARGET_DT), ]
+  expect_equal(33, length(na_time_rows), label="rows with missing TARGET_DT dates")
+})
+
 test_that("format is not supported", {
   # Unsupported data formats
   expect_error(read.socrata('http://soda.demo.socrata.com/resource/4334-bgaj.xml'))


### PR DESCRIPTION
This package has been tested and passed continuous integrating testing. This merged two contributions, #97 and #94. #97 included proper unit tests, but #94 did not need any new tests. 

The code coverage dropped, but I do not think this was of any substance.

@geneorama - can you just take a brief look as well and accept if you concur? We'll keep this around and submit at the end of October to get back on our [regular release schedule](https://github.com/Chicago/RSocrata/wiki/Roadmap). 