### PR TITLE
Reverse fix from #75 since httr integrated changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ r:
 
 warnings_are_errors: true
 
+r_github_packages:
+  - hadley/httr
+
 before_script:
   - Rscript -e 'install.packages("covr", repos="http://mirror.las.iastate.edu/CRAN/")'
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-12
-Date: 2016-03-13
+Version: 1.7.1-13
+Date: 2016-03-31
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -174,7 +174,6 @@ getResponse <- function(url, email = NULL, password = NULL) {
 #'
 #' @author Hugh J. Devlin \email{Hugh.Devlin@@cityofchicago.org}
 #' @importFrom httr content
-#' @importFrom utils read.csv
 #' @param response - an httr response object
 #' @return data frame, possibly empty
 #' @noRd
@@ -186,11 +185,7 @@ getContentAsDataFrame <- function(response) {
   if(sep != -1) mimeType <- substr(mimeType, 0, sep[1] - 1)
   switch(mimeType,
          'text/csv' = 
-           read.csv(textConnection(httr::content(response, 
-                                                 as = "text", 
-                                                 type = "text/csv", 
-                                                 encoding = "utf-8")), 
-                    stringsAsFactors = FALSE), # automatic parsing
+           content(response),
          'application/json' = 
            if(httr::content(response, 
                             as = 'text') == "[ ]") # empty json?


### PR DESCRIPTION
This pull request *undoes* the temporary workaround discussed in #75, which essentially was a problem caused by `httr` dependency on `readr`. 

This undoes that temporary fix since the underlying `readr` problem has been fixed.