### PR TITLE
fixes #15 - provide default sort order if not supplied in URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-15
-Date: 2016-10-06
+Version: 1.7.1-17
+Date: 2016-10-12
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -263,10 +263,15 @@ read.socrata <- function(url, app_token = NULL, email = NULL, password = NULL,
 	parsedUrl <- httr::parse_url(validUrl)
 	mimeType <- mime::guess_type(parsedUrl$path)
 	orderTest <- function (x) x == "$order"
-	if (!is.null(names(parsedUrl$query))) # check if URL has any queries 
+	if (!is.null(names(parsedUrl$query))) { # check if URL has any queries 
 	  if(sum(sapply(names(parsedUrl$query), orderTest)) == 0) # check if URL is sorted
 	    # sort by Socrata unique identifier
-	    validUrl <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, '$order=:id', sep='') 
+	    validUrl <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, '$order=:id', sep='')
+	}
+	else {
+	  validUrl <- paste(validUrl, {'?'}, '$order=:id', sep='')
+	  parsedUrl <- httr::parse_url(validUrl) # reparse because URL now has a query
+	}
 	if(!(mimeType %in% c('text/csv','application/json')))
 		stop("Error in read.socrata: ", mimeType, " not a supported data format.")
 	response <- getResponse(validUrl, email, password)

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -262,6 +262,11 @@ read.socrata <- function(url, app_token = NULL, email = NULL, password = NULL,
 	validUrl <- validateUrl(url, app_token) # check url syntax, allow human-readable Socrata url
 	parsedUrl <- httr::parse_url(validUrl)
 	mimeType <- mime::guess_type(parsedUrl$path)
+	orderTest <- function (x) x == "$order"
+	if (!is.null(names(parsedUrl$query))) # check if URL has any queries 
+	  if(sum(sapply(names(parsedUrl$query), orderTest)) == 0) # check if URL is sorted
+	    # sort by Socrata unique identifier
+	    validUrl <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, '$order=:id', sep='') 
 	if(!(mimeType %in% c('text/csv','application/json')))
 		stop("Error in read.socrata: ", mimeType, " not a supported data format.")
 	response <- getResponse(validUrl, email, password)

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -262,10 +262,10 @@ read.socrata <- function(url, app_token = NULL, email = NULL, password = NULL,
 	validUrl <- validateUrl(url, app_token) # check url syntax, allow human-readable Socrata url
 	parsedUrl <- httr::parse_url(validUrl)
 	mimeType <- mime::guess_type(parsedUrl$path)
-	orderTest <- function (x) x == "$order"
 	if (!is.null(names(parsedUrl$query))) { # check if URL has any queries 
-	  if(sum(sapply(names(parsedUrl$query), orderTest)) == 0) # check if URL is sorted
-	    # sort by Socrata unique identifier
+	  ## if there is a query, check for $order within the query
+	  orderTest <- any(names(parsedUrl$query) == "$order")
+	  if(!orderTest) # sort by Socrata unique identifier
 	    validUrl <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, '$order=:id', sep='')
 	}
 	else {

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -199,6 +199,59 @@ test_that("read Socrata JSON with missing fields (issue 19)", {
   expect_equal(9, ncol(df), label="columns", info = "https://github.com/Chicago/RSocrata/issues/19")
 })
 
+test_that("If URL has no queries, insert $order:id into URL", {
+  ## Define and test issue 15
+  ## Ensure that the $order=:id is inserted when no other query parameters are used.
+  df <- read.socrata("https://data.cityofchicago.org/resource/kn9c-c2s2.json")
+  expect_equal("21.5", df$percent_aged_under_18_or_over_64[7], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("38", df$percent_aged_under_18_or_over_64[23], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("40.4", df$percent_aged_under_18_or_over_64[36], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("36.1", df$percent_aged_under_18_or_over_64[42], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  
+})
+
+test_that("If URL has an $order clause, do not insert ?$order:id into URL", {
+  ## Define and test issue 15
+  ## Ensure that $order=:id is not used when other $order parameters are requested by the user.
+  df <- read.socrata("https://data.cityofchicago.org/resource/kn9c-c2s2.json?$order=hardship_index")
+  expect_equal("35.3", df$percent_aged_under_18_or_over_64[7], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("37.6", df$percent_aged_under_18_or_over_64[23], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("38.5", df$percent_aged_under_18_or_over_64[36], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("32", df$percent_aged_under_18_or_over_64[42], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+})
+
+test_that("If URL has only non-order query parameters, insert $order:id into URL", {
+  ## Define and test issue 15
+  ## Ensure that $order=:id is inserted when other (non-$order) arguments are used.
+  df <- read.socrata("https://data.cityofchicago.org/resource/kn9c-c2s2.json?$limit=50")
+  expect_equal("21.5", df$percent_aged_under_18_or_over_64[7], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("38", df$percent_aged_under_18_or_over_64[23], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("40.4", df$percent_aged_under_18_or_over_64[36], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("36.1", df$percent_aged_under_18_or_over_64[42], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  df <- read.socrata("https://data.cityofchicago.org/resource/kn9c-c2s2.json?$where=hardship_index>20")
+  expect_equal("34", df$percent_aged_under_18_or_over_64[7], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("30.7", df$percent_aged_under_18_or_over_64[23], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("41.2", df$percent_aged_under_18_or_over_64[36], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")
+  expect_equal("42.9", df$percent_aged_under_18_or_over_64[42], 
+               info = "https://github.com/Chicago/RSocrata/issues/15")  
+})
+
+
 context("Checks the validity of 4x4")
 
 test_that("is 4x4", {


### PR DESCRIPTION
If the user does not include an `$order=` in the URL, this will insert `$order=:id`.

There are no tests provided because this issue should only occur when the a dataset is being changed at the same time `read.socrata()` is paging.

fixes #15 