### PR TITLE
Fix read.socrata() when $limit is present in URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-17
-Date: 2016-10-19
+Version: 1.7.1-18
+Date: 2016-10-20
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -274,7 +274,32 @@ read.socrata <- function(url, app_token = NULL, email = NULL, password = NULL,
 	page <- getContentAsDataFrame(response)
 	result <- page
 	dataTypes <- getSodaTypes(response)
-	while (nrow(page) > 0) { # more to come maybe?
+	# parse any $limit out of the URL
+	if(is.null(parsedUrl$query$`$limit`) & is.null(parsedUrl$query$`$LIMIT`))
+	  limitProvided <- FALSE
+	else { 
+	  names(parsedUrl$query) <- tolower(names(parsedUrl$query))
+	  userLimit <- as.integer(parsedUrl$query$`$limit`)
+	  limitProvided <- TRUE
+	  ##remove LIMIT from URL
+	  parsedUrl$query <- parsedUrl$query[-which(names(parsedUrl$query) == '$limit')] 
+	  validUrl <- httr::build_url(parsedUrl)
+	}
+	# PAGE through data and combine
+	# if $limit is <= 1000, do not page
+	# if $limit > 1000, page only until limit is met
+	# if no limit $provided, loop until all data is paged
+	while (nrow(page) > 0) { 
+	  if(limitProvided) 
+	    if(userLimit < 1000) break
+	  else if(userLimit - nrow(result) <= 1000) {
+	    query <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, 
+	                   '$limit=', (userLimit - nrow(result)),'&$offset=', nrow(result), sep='')
+	    response <- getResponse(query, email, password)
+	    page <- getContentAsDataFrame(response)
+	    result <- rbind.fill(result, page) # accumulate
+	    break
+	  }
 		query <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, '$offset=', nrow(result), sep='')
 		response <- getResponse(query, email, password)
 		page <- getContentAsDataFrame(response)

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -210,6 +210,13 @@ test_that("read Socrata JSON with missing fields (issue 19)", {
   expect_equal(9, ncol(df), label="columns", info = "https://github.com/Chicago/RSocrata/issues/19")
 })
 
+test_that("Accept a URL with a $limit= clause and properly limit the results", {
+  ## Define and test issue 83
+  df <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.json?$LIMIT=500")
+  expect_equal(500, nrow(df), label="rows", info = "https://github.com/Chicago/RSocrata/issues/83")
+  expect_equal(11, ncol(df), label="columns", info = "https://github.com/Chicago/RSocrata/issues/83")
+})
+
 context("Checks the validity of 4x4")
 
 test_that("is 4x4", {

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -212,9 +212,18 @@ test_that("read Socrata JSON with missing fields (issue 19)", {
 
 test_that("Accept a URL with a $limit= clause and properly limit the results", {
   ## Define and test issue 83
-  df <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.json?$LIMIT=500")
-  expect_equal(500, nrow(df), label="rows", info = "https://github.com/Chicago/RSocrata/issues/83")
-  expect_equal(11, ncol(df), label="columns", info = "https://github.com/Chicago/RSocrata/issues/83")
+  df <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.json?$LIMIT=500") # uppercase
+  expect_equal(500, nrow(df), label="rows", 
+               info = "$LIMIT in uppercase https://github.com/Chicago/RSocrata/issues/83")
+  df <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.json?$limit=500") # lowercase
+  expect_equal(500, nrow(df), label="rows", 
+               info = "$limit in lowercase https://github.com/Chicago/RSocrata/issues/83")
+  df <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.json?$LIMIT=1001&$order=:id") # uppercase
+  expect_equal(1001, nrow(df), label="rows", 
+               info = "$LIMIT in uppercase with 2 queries https://github.com/Chicago/RSocrata/issues/83")
+  df <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.json?$limit=1001&$order=:id") # lowercase
+  expect_equal(1001, nrow(df), label="rows lowercase", 
+               info = "$LIMIT in lowercase with 2 queries https://github.com/Chicago/RSocrata/issues/83")
 })
 
 context("Checks the validity of 4x4")


### PR DESCRIPTION
fixes #83 and fixes #14 