### PR TITLE
Adds metadata attributes to ls.socrata(). Fixes #72

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-20
-Date: 2016-10-26
+Version: 1.7.1-21
+Date: 2016-10-30
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-21
-Date: 2016-10-30
+Version: 1.7.1-22
+Date: 2016-10-31
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-22
+Version: 1.7.1-23
 Date: 2016-10-31
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -354,7 +354,7 @@ ls.socrata <- function(url) {
     stop(url, " does not appear to be a valid URL.")
   parsedUrl$path <- "data.json"
   df <- jsonlite::fromJSON(httr::build_url(parsedUrl))
-  df <- as.data.frame(df$dataset)
+  df <- as.data.frame(df)
   df$issued <- as.POSIXct(df$issued)
   df$modified <- as.POSIXct(df$modified)
   df$theme <- as.character(df$theme)

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -343,7 +343,10 @@ read.socrata <- function(url, app_token = NULL, email = NULL, password = NULL,
 #' various metadata.
 #' @author Peter Schmiedeskamp \email{pschmied@@uw.edu}
 #' @examples
+#' # Download list of data sets
 #' df <- ls.socrata("http://soda.demo.socrata.com")
+#' # Check schema definition for metadata
+#' attributes(df)
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr parse_url
 #' @export

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -353,14 +353,20 @@ ls.socrata <- function(url) {
   if(is.null(parsedUrl$scheme) | is.null(parsedUrl$hostname))
     stop(url, " does not appear to be a valid URL.")
   parsedUrl$path <- "data.json"
-  df <- jsonlite::fromJSON(httr::build_url(parsedUrl))
-  df <- as.data.frame(df)
-  df$issued <- as.POSIXct(df$issued)
-  df$modified <- as.POSIXct(df$modified)
-  df$theme <- as.character(df$theme)
-  return(df)
+  data_dot_json <- jsonlite::fromJSON(httr::build_url(parsedUrl))
+  data_df <- as.data.frame(data_dot_json$dataset)
+  # Assign Catalog Fields as attributes
+  attr(data_df, "@context") <- data_dot_json$`@context`
+  attr(data_df, "@id") <- data_dot_json$`@id`
+  attr(data_df, "@type") <- data_dot_json$`@type`
+  attr(data_df, "conformsTo") <- data_dot_json$conformsTo
+  attr(data_df, "describedBy") <- data_dot_json$describedBy
+  # Convert dates (strings) to POSIX-formatted dates
+  data_df$issued <- as.POSIXct(data_df$issued)
+  data_df$modified <- as.POSIXct(data_df$modified)
+  data_df$theme <- as.character(data_df$theme)
+  return(data_df)
 }
-
 
 #' Wrap httr PUT/POST in some diagnostics
 #' 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -365,6 +365,8 @@ test_that("incorrect API Query Human Readable", {
   expect_equal(9, ncol(df), label="columns") 
 })
 
+context("ls.socrata functions correctly")
+
 test_that("List datasets available from a Socrata domain", {
   # Makes some potentially erroneous assumptions about availability
   # of soda.demo.socrata.com
@@ -380,6 +382,11 @@ test_that("List datasets available from a Socrata domain", {
   expect_equal(as.logical(rep(TRUE, length(names(df)))), names(df) %in% c(core_names))
 })
 
+test_that("Catalog Fields are assigned as attributes when listing data sets", {
+  df <- ls.socrata("https://soda.demo.socrata.com")
+  catalog_fields <- c("@context", "@id", "@type", "conformsTo", "describedBy")
+  expect_equal(as.logical(rep(TRUE, length(catalog_fields))), catalog_fields %in% names(attributes(df)))
+})
 
 context("Test reading private Socrata dataset with email and password")
 


### PR DESCRIPTION
This provides a fix for #72. 

The [catalog fields](https://project-open-data.cio.gov/v1.1/schema/#Catalog) are now downloaded from Socrata's [Project Open Data Metadata](https://project-open-data.cio.gov/v1.1/schema/) file, data.json, and attaches it as an attribute to the data frame obtained from `ls.socrata()`.

Added a test to ensure that the catalog fields are present as attributes.

@geneorama - can you review this pull request and accept if everything looks good?