### PR TITLE
Bug Fix for issue #120

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-24
-Date: 2016-11-04
+Version: 1.7.2-1
+Date: 2017-2-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -270,9 +270,11 @@ read.socrata <- function(url, app_token = NULL, email = NULL, password = NULL,
   parsedUrl <- httr::parse_url(validUrl)
   mimeType <- mime::guess_type(parsedUrl$path)
   if (!is.null(names(parsedUrl$query))) { # check if URL has any queries 
-    ## if there is a query, check for $order within the query
+    ## if there is a query, check for specific queries and handle them
     orderTest <- any(names(parsedUrl$query) == "$order")
-    if(!orderTest) # sort by Socrata unique identifier
+    queries <- unlist(parsedUrl$query)
+    countTest <- any(startsWith(queries, "count"))
+    if(!orderTest & !countTest) # sort by Socrata unique identifier
       validUrl <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, '$order=:id', sep='')
   }
   else {

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -293,7 +293,7 @@ test_that("Handle URL with query that does not return :id", {
   ## Ensure that the $order=:id is inserted when no other query parameters are used.
   qurl <-  "https://data.cityofchicago.org/resource/wrvz-psew.csv?$select=count(trip_id)&$where=trip_start_timestamp between '2016-04-01T00:00:00' and '2016-04-05T00:00:00'"
   dat <- read.socrata(qurl)
-  expect_equal("1", ncol(dat), 
+  expect_equal(1, ncol(dat), 
                info = "https://github.com/Chicago/RSocrata/issues/120")
 })
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -288,6 +288,16 @@ test_that("If URL has only non-order query parameters, insert $order:id into URL
                info = "https://github.com/Chicago/RSocrata/issues/15")  
 })
 
+test_that("Handle URL with query that does not return :id", {
+  ## Define and test issue 120
+  ## Ensure that the $order=:id is inserted when no other query parameters are used.
+  qurl <-  "https://data.cityofchicago.org/resource/wrvz-psew.csv?$select=count(trip_id)&$where=trip_start_timestamp between '2016-04-01T00:00:00' and '2016-04-05T00:00:00'"
+  dat <- read.socrata(qurl)
+  expect_equal("1", ncol(dat), 
+               info = "https://github.com/Chicago/RSocrata/issues/120")
+})
+
+
 context("Checks the validity of 4x4")
 
 test_that("is 4x4", {


### PR DESCRIPTION
- Fixes a bug (#120) that causes an error when a URL contains a query with a $select=count(x) statement
- When a $select=count(x) statement is present, no $order will be imposed