### PR TITLE
Fixes #121

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-24
-Date: 2016-11-04
+Version: 1.7.2-1
+Date: 2017-02-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-4
+Version: 1.7.2-5
 Date: 2017-02-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-2
+Version: 1.7.2-4
 Date: 2017-02-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Date: 2017-02-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:
-    R (>= 3.0.0)
+    R (>= 3.1.0)
 Imports:
     httr (>= 1.0.0),
     jsonlite (>= 0.9.16),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-1
+Version: 1.7.2-2
 Date: 2017-02-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -112,23 +112,23 @@ posixify <- function(x) {
   
   ## Define regex patterns for short and long date formats (CSV) and ISO 8601 (JSON),  
   ## which are the three formats that are supplied by Socrata. 
-  patternShortCSV <- paste0("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$")
-  patternLongCSV <- paste0("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}",
+  patternShortCsv <- paste0("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$")
+  patternLongCsv <- paste0("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}",
                            "[[:digit:]]{1,2}:[[:digit:]]{1,2}:[[:digit:]]{1,2}",
                            "AM|PM", "$")
-  patternJSON <- paste0("^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T",
+  patternJson <- paste0("^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T",
                         "[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]{3}","$")
   ## Find number of matches with grep
-  nMatchesShortCSV <- grep(pattern = patternShortCSV, x)
-  nMatchesLongCSV <- grep(pattern = patternLongCSV, x)
-  nMatchesJSON <- grep(pattern = patternJSON, x)
+  nMatchesShortCsv <- grep(pattern = patternShortCsv, x)
+  nMatchesLongCsv <- grep(pattern = patternLongCsv, x)
+  nMatchesJson <- grep(pattern = patternJson, x)
   ## Parse as the most likely calendar date format. CSV short/long ties go to short format
-  if(length(nMatchesLongCSV) > length(nMatchesShortCSV)){
+  if(length(nMatchesLongCsv) > length(nMatchesShortCSV)){
     return(as.POSIXct(strptime(x, format="%m/%d/%Y %I:%M:%S %p"))) # long date-time format
-  }	else if (length(nMatchesJSON) == 0){
+  }	else if (length(nMatchesJson) == 0){
     return(as.POSIXct(strptime(x, format="%m/%d/%Y"))) # short date format
   } 
-  if(length(nMatchesJSON) > 0){
+  if(length(nMatchesJson) > 0){
     as.POSIXct(x, format = "%Y-%m-%dT%H:%M:%S") # JSON format
   }
 }

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -133,6 +133,9 @@ posixify <- function(x) {
   } 
   if( any(nMatchesJsonDecimal == TRUE) | any(nMatchesJsonNoDecimal == TRUE) ){
     return(as.POSIXct(x, format = "%Y-%m-%dT%H:%M:%S")) # JSON format
+  } else {
+    warning("Unable to properly format date field; formatted as character string.")
+    return(x)
   }
 }
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -81,13 +81,12 @@ test_that("Date is not entirely NA if the first record is bad (issue 68)", {
   ## Define smaller tests
   dates_clean <- posixify(c("01/01/2011", "01/01/2011", "01/01/2011"))
   dates_mixed <- posixify(c("Date", "01/01/2011", "01/01/2011"))
-  dates_dirty <- posixify(c("Date", "junk", "junk"))
   
   ## Execute smaller tests
   expect_true(all(!is.na(dates_clean)))  ## Nothing should be NA
   expect_true(any(is.na(dates_mixed)))   ## Some should be NA
   expect_true(any(!is.na(dates_mixed)))  ## Some should not be NA
-  expect_true(all(is.na(dates_dirty)))   ## Everything should be NA
+  expect_warning(posixify(c("Date", "junk", "junk"))) ## Should return warning
 })
 
 context("change money to numeric")

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -26,8 +26,7 @@ test_that("read Socrata JSON is compatible with posixify (issue 85)", {
 
 test_that("read Socrata JSON that uses ISO 8601 but does not specify subseconds", {
   df <- read.socrata('https://data.cityofnewyork.us/resource/qcdj-rwhu.json') # Not from #121, but smaller for shorter test process
-  null_dates <- table(is.na(df$app_status_date)) # Count number of null dates
-  expect_true(null_dates == 0, info= "Testing issue 121 https://github.com/Chicago/RSocrata/issues/121")
+  expect_false(anyNA(df$app_status_date), info= "Testing issue 121 https://github.com/Chicago/RSocrata/issues/121")
 })
 
 test_that("posixify returns Long format", {

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -24,6 +24,12 @@ test_that("read Socrata JSON is compatible with posixify (issue 85)", {
   expect_equal(dt, df$datetime[1], info= "Testing Issue 85 https://github.com/Chicago/RSocrata/issues/85")  ## Check that download matches test
 })
 
+test_that("read Socrata JSON that uses ISO 8601 but does not specify subseconds", {
+  df <- read.socrata('https://data.cityofnewyork.us/resource/qcdj-rwhu.json') # Not from #121, but smaller for shorter test process
+  null_dates <- table(is.na(df$app_status_date)) # Count number of null dates
+  expect_true(null_dates == 0, info= "Testing issue 121 https://github.com/Chicago/RSocrata/issues/121")
+})
+
 test_that("posixify returns Long format", {
   dt <- posixify("09/14/2012 10:38:01 PM")
   expect_equal("POSIXct", class(dt)[1], label="Long format date data type")


### PR DESCRIPTION
* Add ability to handle date/time formats as `YYYY-MM-DDTHH:MM:SS` -- fixes #121
* If the date/time format is not properly converted, RSocrata returns the data as `chr` strings instead of `NA`. This will let the user manually convert if necessary and will reduce the severity of errors like these in the future (there are several date formats we are not handling right now)
* A warning has been added to alert users they will not have a POSIX-formatted column.