### PR TITLE
Closes #129

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-7
-Date: 2017-03-04
+Version: 1.7.2-8
+Date: 2017-03-09
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:


### PR DESCRIPTION
I simplified some of the paging code in addition to setting the default to 50k. 

For some reason the diff is showing that the file was replaced entirely. I cannot get the diff to show only the changed code. Lines 301-329 of the old code turns into lines 301-315 of the new code. 