### PR TITLE
Release Candidate 1 for 1.7.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,5 @@
 \.gitignore
+\.gitattributes
 \.project
 \.settings
 \.Rbuildignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare R files to use CRLF line endings
+*.R text col=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ sudo: false
 language: r
 cache: packages
 r:
-  - oldrel
   - release
   - devel
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,13 @@ If you have multiple issues, please submit multiple requests. Once you submit yo
 When you want to make a change, either to fix a bug or introduce a new feature, please follow the instructions below
 
 * Create a branch or fork of the project based off of the `dev` branch.
-* Make commits of logical units
-* Add unit tests for any new features
+* Make commits of logical units.
+* Add unit tests for any new features.
+* Document any new functions or new arguments within any existing function.
 * Iterate either version or build number in the `DESCRIPTION` file:
   * The version number follows the `x.y.z-build` format and increments based on [semantic versioning 2.0.0](http://semver.org/spec/v2.0.0.html). Please update versions corresponding to those guidelines.
   * If your contribution takes several commits, please increment the build number (e.g., x.y.z-build) so there is a unique relationship of the version-build number to each commit.
-* Run all tests in `tests/testthat/`
-* Create a pull request with a robust description or [reference the issue number](https://github.com/Chicago/RSocrata/issues)
+* Update the DESCRIPTION file for any new dependencies on packages or minimum verson of R required (up to the current release of R).
+* Run all tests in `tests/testthat/`.
+* Create a pull request with a robust description or [reference the issue number](https://github.com/Chicago/RSocrata/issues) to the `dev` branch (read the package's [formal git-flow policy](https://github.com/Chicago/RSocrata/wiki/Git-Flow)).
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,12 +10,12 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-8
-Date: 2017-03-09
+Version: 1.7.2-9
+Date: 2017-03-15
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:
-    R (>= 3.1.0)
+    R (>= 3.3.0)
 Imports:
     httr (>= 1.0.0),
     jsonlite (>= 0.9.16),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-24
-Date: 2016-11-04
+Version: 1.7.2-1
+Date: 2017-2-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-7
-Date: 2017-03-04
+Version: 1.7.2-8
+Date: 2017-03-09
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,12 +10,12 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-1
-Date: 2017-2-23
+Version: 1.7.2-7
+Date: 2017-03-04
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:
-    R (>= 3.0.0)
+    R (>= 3.1.0)
 Imports:
     httr (>= 1.0.0),
     jsonlite (>= 0.9.16),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-10
+Version: 1.7.2-11
 Date: 2017-03-15
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-11
-Date: 2017-03-15
+Version: 1.7.2-12
+Date: 2017-03-16
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.1-24
-Date: 2016-11-04
+Version: 1.7.2-1
+Date: 2016-11-16
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -65,11 +65,19 @@ Bug fixes:
 
 ### 1.7.2 Several changes:
 
-Internal changes:
+Performance improvements:
 
-* By default, 1000 rows at a time were being retreived for each API call while paging through data. Increased to retreive 50,000 rows for each API call.
+* By default, 1000 rows at a time were being retreived for each API call while paging through data. Increased to retreive 50,000 rows for each API call. ([#129](https://github.com/Chicago/RSocrata/issues/129))
 
 Bug fixes:
 
 * Fixed a bug which caused an error if a ```select=count()``` statement was present in a URL. ([#120](https://github.com/Chicago/RSocrata/issues/120))
 * Fixed a bug when data types are not found because there are no ```X-SODA2-*``` headers available in the API response. Users will now get a warning and data will be returned as ```character```. ([#118](https://github.com/Chicago/RSocrata/issues/118))
+* Fixed a bug which did not recognize URLs listed from ```ls.socrata()``` as valid URLs to be used in ```read.socrata()```. Users will now be able to use URLs from the former function in the latter function. ([#124](https://github.com/Chicago/RSocrata/issues/124))
+* Removed unit tests for older releases of R. ([#136](https://github.com/Chicago/RSocrata/issues/136)) 
+
+Deprecation:
+
+RSocrata's core development team has stated a formal policy to only support the most recent release of R. Until now, RSocrata was tested against the penultimate release of R; however, testing will be limited to the current version of R and the current development release. The project's [contributing guidelines](https://github.com/Chicago/RSocrata/blob/master/CONTRIBUTING.md) have been updated to reflect that accepted changes to RSocrata must pass tests on the current and penulimate versions of R.
+
+While RSocrata is only tested on the current and penultimate version, the core development team expects it will work on older versions most of the time. See [#132](https://github.com/Chicago/RSocrata/issues/132) for more information.

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,3 +63,13 @@ Bug fixes:
 * Fixes a bug where the POSIX date conversion would not occur when using the JSON SoDA url (#85)
 * Queries now follow SoDA guidelines and are explicitly sorted. This could have caused a silent error where some row may not have downloaded. ([#15](https://github.com/Chicago/RSocrata/issues/15))
 
+### 1.7.2 Several changes:
+
+Internal changes:
+
+* By default, 1000 rows at a time were being retreived for each API call while paging through data. Increased to retreive 50,000 rows for each API call.
+
+Bug fixes:
+
+* Fixed a bug which caused an error if a ```select=count()``` statement was present in a URL. ([#120](https://github.com/Chicago/RSocrata/issues/120))
+* Fixed a bug when data types are not found because there are no ```X-SODA2-*``` headers available in the API response. Users will now get a warning and data will be returned as ```character```. ([#118](https://github.com/Chicago/RSocrata/issues/118))

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -74,7 +74,11 @@ validateUrl <- function(url, app_token) {
   } 
   if(substr(parsedUrl$path, 1, 9) == 'resource/') {
     return(httr::build_url(parsedUrl)) # resource url already
+  } else if(basename(parsedUrl$path) == "rows.json" | basename(parsedUrl$path) == "rows.csv") { # See issue #124
+    parsedUrl$path <- substr(parsedUrl$path, start = 11, stop = 19)
+    parsedUrl$query <- NULL
   }
+  
   fourByFour <- basename(parsedUrl$path)
   if(!isFourByFour(fourByFour))
     stop(fourByFour, " is not a valid Socrata dataset unique identifier.")
@@ -112,24 +116,30 @@ posixify <- function(x) {
   
   ## Define regex patterns for short and long date formats (CSV) and ISO 8601 (JSON),  
   ## which are the three formats that are supplied by Socrata. 
-  patternShortCSV <- paste0("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$")
-  patternLongCSV <- paste0("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}",
+  patternShortCsv <- paste0("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}$") # MM/DD/YYYY
+  patternLongCsv <- paste("^[[:digit:]]{1,2}/[[:digit:]]{1,2}/[[:digit:]]{4}", 
                            "[[:digit:]]{1,2}:[[:digit:]]{1,2}:[[:digit:]]{1,2}",
-                           "AM|PM", "$")
-  patternJSON <- paste0("^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T",
-                        "[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]{3}","$")
+                           ".M$") # MM/DD/YYYY hh:mm:ss AM/PM
+  patternJsonDecimal <- paste0("^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T",
+                               "[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]{3}","$") # YYYY-MM-DDThh:mm:ss.sss
+  patternJsonNoDecimal <- paste0("^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T",
+                                 "[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}","$") # YYYY-MM-DDThh:mm:ss
   ## Find number of matches with grep
-  nMatchesShortCSV <- grep(pattern = patternShortCSV, x)
-  nMatchesLongCSV <- grep(pattern = patternLongCSV, x)
-  nMatchesJSON <- grep(pattern = patternJSON, x)
+  nMatchesShortCsv <- grepl(pattern = patternShortCsv, x)
+  nMatchesLongCsv <- grepl(pattern = patternLongCsv, x)
+  nMatchesJsonDecimal <- grepl(pattern = patternJsonDecimal, x)
+  nMatchesJsonNoDecimal <- grepl(pattern = patternJsonNoDecimal, x)
   ## Parse as the most likely calendar date format. CSV short/long ties go to short format
-  if(length(nMatchesLongCSV) > length(nMatchesShortCSV)){
+  if( any(nMatchesLongCsv == TRUE) ){
     return(as.POSIXct(strptime(x, format="%m/%d/%Y %I:%M:%S %p"))) # long date-time format
-  }	else if (length(nMatchesJSON) == 0){
+  }	else if ( any(nMatchesShortCsv == TRUE) ){
     return(as.POSIXct(strptime(x, format="%m/%d/%Y"))) # short date format
   } 
-  if(length(nMatchesJSON) > 0){
-    as.POSIXct(x, format = "%Y-%m-%dT%H:%M:%S") # JSON format
+  if( any(nMatchesJsonDecimal == TRUE) | any(nMatchesJsonNoDecimal == TRUE) ){
+    return(as.POSIXct(x, format = "%Y-%m-%dT%H:%M:%S")) # JSON format
+  } else {
+    warning("Unable to properly format date field; formatted as character string.")
+    return(x)
   }
 }
 

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -270,9 +270,11 @@ read.socrata <- function(url, app_token = NULL, email = NULL, password = NULL,
   parsedUrl <- httr::parse_url(validUrl)
   mimeType <- mime::guess_type(parsedUrl$path)
   if (!is.null(names(parsedUrl$query))) { # check if URL has any queries 
-    ## if there is a query, check for $order within the query
+    ## if there is a query, check for specific queries and handle them
     orderTest <- any(names(parsedUrl$query) == "$order")
-    if(!orderTest) # sort by Socrata unique identifier
+    queries <- unlist(parsedUrl$query)
+    countTest <- any(startsWith(queries, "count"))
+    if(!orderTest & !countTest) # sort by Socrata unique identifier
       validUrl <- paste(validUrl, if(is.null(parsedUrl$query)) {'?'} else {"&"}, '$order=:id', sep='')
   }
   else {

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ RSocrata
 
 **Master** 
 
+Stable beta branch. Test about-to-be-released features in a stable pre-release build before it is submitted to CRAN.
+
 [![Linux build - Master](https://img.shields.io/travis/Chicago/RSocrata/master.svg?style=flat-square&label=Linux build)](https://travis-ci.org/Chicago/RSocrata)[![Windows build - Master](https://img.shields.io/appveyor/ci/tomschenkjr/RSocrata/master.svg?style=flat-square&label=Windows build)](https://ci.appveyor.com/project/tomschenkjr/rsocrata/branch/master)[![Coverage - Master](https://img.shields.io/coveralls/Chicago/RSocrata/master.svg?style=flat-square&label=Coverage - Master)](https://coveralls.io/r/Chicago/RSocrata?branch=master)
 
 **Dev**
+
+"Nightly" alpha branch. Test the latest features and bug fixes -- enjoy at your own risk.
 
 [![Linux build - Dev](https://img.shields.io/travis/Chicago/RSocrata/dev.svg?style=flat-square&label=Linux build)](https://travis-ci.org/Chicago/RSocrata)[![Windows build - Dev](https://img.shields.io/appveyor/ci/tomschenkjr/RSocrata/dev.svg?style=flat-square&label=Windows build)](https://ci.appveyor.com/project/tomschenkjr/rsocrata/branch/dev)[![Coverage - Dev](https://img.shields.io/coveralls/Chicago/RSocrata/dev.svg?style=flat-square&label=Coverage status - Dev)](https://coveralls.io/r/Chicago/RSocrata?branch=dev)
 
@@ -40,11 +44,18 @@ To get the current released version from CRAN:
 install.packages("RSocrata")
 ```
 
-To get the current development version from github:
+To get the current beta with soon-to-be-released changes is on GitHub:
 
 ```R
 # install.packages("devtools")
 devtools::install_github("Chicago/RSocrata")
+```
+
+The "nightly" version with the most recent bug fixes and features is also available:
+
+```R
+# install.packages("devtools")
+devtools::install_github("Chicago/RSocrata", ref="dev")
 ```
 
 ### Example: Reading SoDA valid URLs

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ RSocrata
 
 Stable beta branch. Test about-to-be-released features in a stable pre-release build before it is submitted to CRAN.
 
-[![Linux build - Master](https://img.shields.io/travis/Chicago/RSocrata/master.svg?style=flat-square&label=Linux build)](https://travis-ci.org/Chicago/RSocrata)[![Windows build - Master](https://img.shields.io/appveyor/ci/tomschenkjr/RSocrata/master.svg?style=flat-square&label=Windows build)](https://ci.appveyor.com/project/tomschenkjr/rsocrata/branch/master)[![Coverage - Master](https://img.shields.io/coveralls/Chicago/RSocrata/master.svg?style=flat-square&label=Coverage - Master)](https://coveralls.io/r/Chicago/RSocrata?branch=master)
+[![Linux build - Master](https://img.shields.io/travis/Chicago/RSocrata/master.svg?style=flat-square&label=Linux%20build)](https://travis-ci.org/Chicago/RSocrata)[![Windows build - Master](https://img.shields.io/appveyor/ci/tomschenkjr/RSocrata/master.svg?style=flat-square&label=Windows%20build)](https://ci.appveyor.com/project/tomschenkjr/rsocrata/branch/master)[![Coverage - Master](https://img.shields.io/coveralls/Chicago/RSocrata/master.svg?style=flat-square&label=Coverage)](https://coveralls.io/r/Chicago/RSocrata?branch=master)
 
 **Dev**
 
 "Nightly" alpha branch. Test the latest features and bug fixes -- enjoy at your own risk.
 
-[![Linux build - Dev](https://img.shields.io/travis/Chicago/RSocrata/dev.svg?style=flat-square&label=Linux build)](https://travis-ci.org/Chicago/RSocrata)[![Windows build - Dev](https://img.shields.io/appveyor/ci/tomschenkjr/RSocrata/dev.svg?style=flat-square&label=Windows build)](https://ci.appveyor.com/project/tomschenkjr/rsocrata/branch/dev)[![Coverage - Dev](https://img.shields.io/coveralls/Chicago/RSocrata/dev.svg?style=flat-square&label=Coverage status - Dev)](https://coveralls.io/r/Chicago/RSocrata?branch=dev)
+[![Linux build - Dev](https://img.shields.io/travis/Chicago/RSocrata/dev.svg?style=flat-square&label=Linux%20build)](https://travis-ci.org/Chicago/RSocrata)[![Windows build - Dev](https://img.shields.io/appveyor/ci/tomschenkjr/RSocrata/dev.svg?style=flat-square&label=Windows%20build)](https://ci.appveyor.com/project/tomschenkjr/rsocrata/branch/dev)[![Coverage - Dev](https://img.shields.io/coveralls/Chicago/RSocrata/dev.svg?style=flat-square&label=Coverage)](https://coveralls.io/r/Chicago/RSocrata?branch=dev)
 
 A tool for downloading and uploading Socrata datasets
 -----------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Use ```ls.socrata()``` to list all datasets available on a Socrata webserver.
 
 [testthat](https://cran.r-project.org/package=testthat) test coverage.
 
-Installation
--------------
+## Installation
+
 
 To get the current released version from CRAN:
 
@@ -58,28 +58,31 @@ The "nightly" version with the most recent bug fixes and features is also availa
 devtools::install_github("Chicago/RSocrata", ref="dev")
 ```
 
-### Example: Reading SoDA valid URLs
+Examples
+--------
+
+### Reading SoDA valid URLs
 ```r
 earthquakesDataFrame <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.csv")
 nrow(earthquakesDataFrame) # 1007 (two "pages")
 class(earthquakesDataFrame$Datetime[1]) # POSIXlt
 ```
 
-### Example: Reading "human-readable" URLs
+### Reading "human-readable" URLs
 ```r
 earthquakesDataFrame <- read.socrata("https://soda.demo.socrata.com/dataset/USGS-Earthquakes-for-2012-11-01-API-School-Demo/4334-bgaj")
 nrow(earthquakesDataFrame) # 1007 (two "pages")
 class(earthquakesDataFrame$Datetime[1]) # POSIXlt
 ```
 
-### Example: Using API key to read datasets
+### Using API key to read datasets
 ```r
 token <- "ew2rEMuESuzWPqMkyPfOSGJgE"
 earthquakesDataFrame <- read.socrata("http://soda.demo.socrata.com/resource/4334-bgaj.csv", app_token = token)
 nrow(earthquakesDataFrame)
 ```
 
-### Example: Download private datasets from portal
+### Download private datasets from portal
 ```r
 # Store user email and password
 socrataEmail <- Sys.getenv("SOCRATA_EMAIL", "mark.silverberg+soda.demo@socrata.com")
@@ -90,14 +93,14 @@ privateResourceToReadCsvUrl <- "https://soda.demo.socrata.com/resource/a9g2-feh2
 read.socrata(url = privateResourceToReadCsvUrl, email = socrataEmail, password = socrataPassword)
 ```
 
-### Example: List all datasets on portal
+### List all datasets on portal
 ```r
 allSitesDataFrame <- ls.socrata("https://soda.demo.socrata.com")
 nrow(allSitesDataFrame) # Number of datasets
 allSitesDataFrame$title # Names of each dataset
 ```
 
-### Example: Upload data to portal
+### Upload data to portal
 ```r
 # Store user email and password
 socrataEmail <- Sys.getenv("SOCRATA_EMAIL", "mark.silverberg+soda.demo@socrata.com")
@@ -114,10 +117,10 @@ df_in <- data.frame(x,y)
 write.socrata(df_in,datasetToAddToUrl,"UPSERT",socrataEmail,socrataPassword)
 ```
 
-### Issues
+## Issues
 
 Please report issues, request enhancements or fork us at the [City of Chicago github](https://github.com/Chicago/RSocrata/issues).
 
-### Contributing
+## Contributing
 
 If you would like to contribute to this project, please see the [contributing documentation](CONTRIBUTING.md) and the [product roadmap](https://github.com/Chicago/RSocrata/wiki/Roadmap#planned-releases).

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ To get the current released version from CRAN:
 install.packages("RSocrata")
 ```
 
-To get the current beta with soon-to-be-released changes is on GitHub:
+The most recent beta with soon-to-be-released changes can be installed from GitHub:
 
 ```R
 # install.packages("devtools")
 devtools::install_github("Chicago/RSocrata")
 ```
 
-The "nightly" version with the most recent bug fixes and features is also available:
+The "nightly" version with the most recent bug fixes and features is also available. This version is always an alpha and may contain significant bugs. You can install it from the `dev` branch from GitHub:
 
 ```R
 # install.packages("devtools")

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -107,6 +107,16 @@ test_that("read Socrata CSV as default", {
                label="testing column CSV classes with defaults")
 })
 
+test_that("read Socrata CSV from New Backend (NBE) endpoint", {
+  df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.csv")
+  expect_equal("data.frame", class(df), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(68087, nrow(df), label="rows", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(4, ncol(df), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(c("character", "character", "character", "numeric"), 
+               unname(sapply(sapply(df, class),`[`, 1)), 
+               label="testing column CSV classes with defaults")
+})
+
 test_that("read Socrata CSV as character", {
   df <- read.socrata('https://soda.demo.socrata.com/resource/4334-bgaj.csv',
                      stringsAsFactors = FALSE)

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -293,7 +293,7 @@ test_that("Handle URL with query that does not return :id", {
   ## Ensure that the $order=:id is inserted when no other query parameters are used.
   qurl <-  "https://data.cityofchicago.org/resource/wrvz-psew.csv?$select=count(trip_id)&$where=trip_start_timestamp between '2016-04-01T00:00:00' and '2016-04-05T00:00:00'"
   dat <- read.socrata(qurl)
-  expect_equal("1", ncol(dat), 
+  expect_equal(1, ncol(dat), 
                info = "https://github.com/Chicago/RSocrata/issues/120")
 })
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -120,6 +120,12 @@ test_that("read Socrata CSV from New Backend (NBE) endpoint", {
                label="testing column CSV classes with defaults")
 })
 
+test_that("Warn instead of fail if X-SODA2-* headers are missing", {
+  dfJson <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.json")
+  dfCsv <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.csv")
+  ## the above will fail, more tests to come 
+})
+
 test_that("read Socrata CSV as character", {
   df <- read.socrata('https://soda.demo.socrata.com/resource/4334-bgaj.csv',
                      stringsAsFactors = FALSE)

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -111,6 +111,16 @@ test_that("read Socrata CSV as default", {
                label="testing column CSV classes with defaults")
 })
 
+test_that("read Socrata CSV from New Backend (NBE) endpoint", {
+  df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.csv")
+  expect_equal("data.frame", class(df), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(68087, nrow(df), label="rows", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(4, ncol(df), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(c("character", "character", "character", "numeric"), 
+               unname(sapply(sapply(df, class),`[`, 1)), 
+               label="testing column CSV classes with defaults")
+})
+
 test_that("read Socrata CSV as character", {
   df <- read.socrata('https://soda.demo.socrata.com/resource/4334-bgaj.csv',
                      stringsAsFactors = FALSE)

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -121,9 +121,16 @@ test_that("read Socrata CSV from New Backend (NBE) endpoint", {
 })
 
 test_that("Warn instead of fail if X-SODA2-* headers are missing", {
-  dfJson <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.json")
-  dfCsv <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.csv")
-  ## the above will fail, more tests to come 
+  expect_warning(dfCsv <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.csv?$limit=1000"),
+                info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_warning(dfJson <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.json?$limit=1000"),
+                info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_silent(df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.csv"))
+  expect_silent(df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.json"))
+  expect_equal("data.frame", class(dfCsv), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal("data.frame", class(dfJson), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(150, ncol(dfCsv), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(140, ncol(dfJson), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
 })
 
 test_that("read Socrata CSV as character", {

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -288,6 +288,16 @@ test_that("If URL has only non-order query parameters, insert $order:id into URL
                info = "https://github.com/Chicago/RSocrata/issues/15")  
 })
 
+test_that("Handle URL with query that does not return :id", {
+  ## Define and test issue 120
+  ## Ensure that the $order=:id is inserted when no other query parameters are used.
+  qurl <-  "https://data.cityofchicago.org/resource/wrvz-psew.csv?$select=count(trip_id)&$where=trip_start_timestamp between '2016-04-01T00:00:00' and '2016-04-05T00:00:00'"
+  dat <- read.socrata(qurl)
+  expect_equal("1", ncol(dat), 
+               info = "https://github.com/Chicago/RSocrata/issues/120")
+})
+
+
 context("Checks the validity of 4x4")
 
 test_that("is 4x4", {

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -114,9 +114,8 @@ test_that("read Socrata CSV as default", {
 test_that("read Socrata CSV from New Backend (NBE) endpoint", {
   df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.csv")
   expect_equal("data.frame", class(df), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_equal(68087, nrow(df), label="rows", info="https://github.com/Chicago/RSocrata/issues/118")
   expect_equal(4, ncol(df), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_equal(c("character", "character", "character", "numeric"), 
+  expect_equal(c("character", "character", "integer", "character"), 
                unname(sapply(sapply(df, class),`[`, 1)), 
                label="testing column CSV classes with defaults")
 })

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -24,6 +24,11 @@ test_that("read Socrata JSON is compatible with posixify (issue 85)", {
   expect_equal(dt, df$datetime[1], info= "Testing Issue 85 https://github.com/Chicago/RSocrata/issues/85")  ## Check that download matches test
 })
 
+test_that("read Socrata JSON that uses ISO 8601 but does not specify subseconds", {
+  df <- read.socrata('https://data.cityofnewyork.us/resource/qcdj-rwhu.json') # Not from #121, but smaller for shorter test process
+  expect_false(anyNA(df$app_status_date), info= "Testing issue 121 https://github.com/Chicago/RSocrata/issues/121")
+})
+
 test_that("posixify returns Long format", {
   dt <- posixify("09/14/2012 10:38:01 PM")
   expect_equal("POSIXct", class(dt)[1], label="Long format date data type")
@@ -76,13 +81,12 @@ test_that("Date is not entirely NA if the first record is bad (issue 68)", {
   ## Define smaller tests
   dates_clean <- posixify(c("01/01/2011", "01/01/2011", "01/01/2011"))
   dates_mixed <- posixify(c("Date", "01/01/2011", "01/01/2011"))
-  dates_dirty <- posixify(c("Date", "junk", "junk"))
   
   ## Execute smaller tests
   expect_true(all(!is.na(dates_clean)))  ## Nothing should be NA
   expect_true(any(is.na(dates_mixed)))   ## Some should be NA
   expect_true(any(!is.na(dates_mixed)))  ## Some should not be NA
-  expect_true(all(is.na(dates_dirty)))   ## Everything should be NA
+  expect_warning(posixify(c("Date", "junk", "junk"))) ## Should return warning
 })
 
 context("change money to numeric")
@@ -187,6 +191,18 @@ test_that("URL is private (Unauthorized) (will fail)", {
 test_that("readSocrataHumanReadable", {
   df <- read.socrata('https://soda.demo.socrata.com/dataset/USGS-Earthquake-Reports/4334-bgaj')
   expect_equal(1007, nrow(df), label="rows")
+  expect_equal(9, ncol(df), label="columns")
+})
+
+test_that("Read URL provided by data.json from ls.socrata() - CSV", {
+  df <- read.socrata('https://soda.demo.socrata.com/api/views/4334-bgaj/rows.csv?accessType=DOWNLOAD')
+  expect_equal(1007, nrow(df), label="rows", info="Testing for issue #124")
+  expect_equal(9, ncol(df), label="columns")
+})
+
+test_that("Read URL provided by data.json from ls.socrata() - JSON", {
+  df <- read.socrata('https://soda.demo.socrata.com/api/views/4334-bgaj/rows.json?accessType=DOWNLOAD')
+  expect_equal(1007, nrow(df), label="rows", info="Testing for issue #124")
   expect_equal(9, ncol(df), label="columns")
 })
 


### PR DESCRIPTION
Version 1.7.2 has several changes:

#### Performance improvements:

* By default, 1000 rows at a time were being retreived for each API call while paging through data. Increased to retreive 50,000 rows for each API call. (#129)

#### Bug fixes:

* Fixed a bug which caused an error if a select=count() statement was present in a URL. (#120)
* Fixed a bug when data types are not found because there are no X-SODA2-* headers available in the API response. Users will now get a warning and data will be returned as character. (#118)
* Fixed a bug which did not recognize URLs listed from ls.socrata() as valid URLs to be used in read.socrata(). Users will now be able to use URLs from the former function in the latter function. (#124)
* Removed unit tests for older releases of R. (#136)

#### Deprecation:

RSocrata's core development team has stated a formal policy to only support the most recent release of R. Until now, RSocrata was tested against the penultimate release of R; however, testing will be limited to the current version of R and the current development release. The project's contributing guidelines have been updated to reflect that accepted changes to RSocrata must pass tests on the current and penulimate versions of R.

While RSocrata is only tested on the current and penultimate version, the core development team expects it will work on older versions most of the time. See #132 for more information.