### PR TITLE
Hot patch to fix #141

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.2-12
-Date: 2017-03-16
+Version: 1.7.3-1
+Date: 2017-06-22
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to Socrata portals directly
     from R.
-Version: 1.7.3-1
+Version: 1.7.3-2
 Date: 2017-06-22
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., and John Malc
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -468,7 +468,7 @@ test_that("converts money fields to numeric", {
   expect_equal(15000, numeric_money, label="dollars")
   # Use data from Socrata
   df <- read.socrata("https://data.cityofchicago.org/Administration-Finance/Current-Employee-Names-Salaries-and-Position-Title/xzkq-xp2w")
-  expect_equal("numeric", class(df$Employee.Annual.Salary))
+  expect_equal("numeric", class(df$Annual.Salary))
 })
   
 context("write Socrata datasets")

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -98,6 +98,12 @@ test_that("Fields with currency symbols remove the symbol and convert to money",
   expect_equal("numeric", class(deniro), label="output of money fields")
 })
 
+test_that("converts money fields to numeric from Socrata", {
+  df <- read.socrata("https://data.cityofchicago.org/Administration-Finance/Current-Employee-Names-Salaries-and-Position-Title/xzkq-xp2w")
+  expect_equal("numeric", class(df$Annual.Salary), label="dollars")
+  expect_equal("numeric", class(df$Annual.Salary), label="output of money fields")
+})
+
 context("read Socrata")
 
 test_that("read Socrata CSV as default", {
@@ -461,16 +467,6 @@ test_that("read Socrata JSON that requires a login", {
   expect_equal(3, nrow(df), label="rows")
 })
 
-test_that("converts money fields to numeric", {
-  # Manual check 
-  money <- "$15000"
-  numeric_money <- no_deniro(money)
-  expect_equal(15000, numeric_money, label="dollars")
-  # Use data from Socrata
-  df <- read.socrata("https://data.cityofchicago.org/Administration-Finance/Current-Employee-Names-Salaries-and-Position-Title/xzkq-xp2w")
-  expect_equal("numeric", class(df$Annual.Salary))
-})
-  
 context("write Socrata datasets")
 
 test_that("add a row to a dataset", {


### PR DESCRIPTION
Per #141, a unit test began to fail on converting money fields to numeric in an R data frame. The cause was a change in the API field name on Chicago's data portal as part of a larger reorganization of the data.

This fix has two parts:

 * Changed the name of the column so the test would pass
 * Consolidated tests regarding the `no_dinero` function, which was duplicated in two parts of the testing scripts.

I've opened the pull request directly against the `master` branch, instead of the `dev` branch. Currently, the `dev` branch contains early work for v1.8.0, so I don't want to conflate the two. Since this is a limited hot patch, I've branched from `master` and am resubmitting to that same branch.

Both AppVeyor and Travis tests have passed.

Please review and concur with the changes.