### PR TITLE
#154 add support for $query syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to 'Socrata' portals directly
     from R.
-Version: 1.8.0-8
+Version: 1.8.0-9
 Date: 2018-01-15
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., Gene Leynes, Nick Lucius, John Malc, Mark Silverberg, and Peter Schmeideskamp
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -375,6 +375,12 @@ test_that("CSV with Token", {
   expect_equal(9, ncol(df), label="columns")  
 })
 
+test_that("CSV with Token and query string", {
+  df <- read.socrata('https://soda.demo.socrata.com/resource/4334-bgaj.csv?$query=select depth', app_token="ew2rEMuESuzWPqMkyPfOSGJgE")
+  expect_equal(1000, nrow(df), label="rows")
+  expect_equal(1, ncol(df), label="columns")  
+})
+
 
 test_that("readSocrataHumanReadableToken", {
   df <- read.socrata('https://soda.demo.socrata.com/dataset/USGS-Earthquake-Reports/4334-bgaj', app_token="ew2rEMuESuzWPqMkyPfOSGJgE")


### PR DESCRIPTION
Added basic support for soql $query syntax. 

Basically just moves any $query to the end of the query string, and disables adding offset, count and limit when $query is present.

