### PR TITLE
Hot patch to fix #158

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to 'Socrata' portals directly
     from R.
-Version: 1.7.4-7
-Date: 2017-12-20
+Version: 1.7.5-1
+Date: 2019-01-17
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., Gene Leynes, Nick Lucius, John Malc, Mark Silverberg, and Peter Schmeideskamp
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -100,8 +100,8 @@ test_that("Fields with currency symbols remove the symbol and convert to money",
 
 test_that("converts money fields to numeric from Socrata", {
   df <- read.socrata("https://data.cityofchicago.org/Administration-Finance/Current-Employee-Names-Salaries-and-Position-Title/xzkq-xp2w")
-  expect_equal("numeric", class(df$Annual.Salary), label="dollars")
-  expect_equal("numeric", class(df$Annual.Salary), label="output of money fields")
+  expect_equal("numeric", class(df$annual_salary), label="dollars")
+  expect_equal("numeric", class(df$annual_salary), label="output of money fields")
 })
 
 context("read Socrata")


### PR DESCRIPTION
Per #158, a unit test began to fail due to a change in format of column names in a sample dataset used in testing. This fix is simply to change the column names in the test script to match the names in the incoming dataset.

I've opened the pull request directly against the master branch, instead of the dev branch. Currently, the dev branch contains early work for v1.8.0, so I don't want to conflate the two. Since this is a limited hot patch, I've branched from master and am resubmitting to that same branch.

I've modeled this pull request on #142, which dealt with a nearly identical situation.