### PR TITLE
update readme with clarifying socrata api documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to 'Socrata' portals directly
     from R.
-Version: 1.8.0-10
-Date: 2019-01-27
+Version: 1.8.0-11
+Date: 2019-09-10
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., Gene Leynes, Nick Lucius, John Malc, Mark Silverberg, and Peter Schmeideskamp
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ allSitesDataFrame$title # Names of each dataset
 ```
 
 ### Upload data to portal
+
+Note: ```write.socrata()``` writes directly to Socrata datasets using the Socrata Open Data API, which differs in functionality from the [Socrata Data Management API](https://socratapublishing.docs.apiary.io/#). Creating datasets with the Socrata user interface, or directly with the Data Management API, uses drafts to stage and transform data during the data ingress cycle. With any data updates to Socrata datasets that utilize one or more on-platform data transformations (like adding a georeference), use the Data Management API to continue to apply those transformations to any new data. If your dataset schema is exactly the same between your source and the Socrata dataset, and you do not need the on-platform transform functionality, the SODA API and ```write.socrata()``` will continue to perform as expected. For more on the difference between the SODA API and the Socrata Data Management API, see the latter API's documentation [here](https://socratapublishing.docs.apiary.io/#).
+
 ```r
 # Store user email and password
 socrataEmail <- Sys.getenv("SOCRATA_EMAIL", "mark.silverberg+soda.demo@socrata.com")


### PR DESCRIPTION
Adding a note describing differences in writing to Socrata datasets from RSocrata/SODA compared to the Data Management API. This is to help prevent confusion when automating data updates to Socrata that should make use of transforms applied on the platform during ingress.