### PR TITLE
Fixes #183

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to 'Socrata' portals directly
     from R.
-Version: 1.7.9-5
-Date: 2019-06-24
+Version: 1.7.10-4
+Date: 2019-10-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., Gene Leynes, Nick Lucius, John Malc, Mark Silverberg, and Peter Schmeideskamp
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to 'Socrata' portals directly
     from R.
-Version: 1.7.10-5
+Version: 1.7.10-6
 Date: 2019-10-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., Gene Leynes, Nick Lucius, John Malc, Mark Silverberg, and Peter Schmeideskamp
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides easier interaction with
     format and manages throttling by 'Socrata'.
     Users can upload data to 'Socrata' portals directly
     from R.
-Version: 1.7.10-4
+Version: 1.7.10-5
 Date: 2019-10-23
 Author: Hugh Devlin, Ph. D., Tom Schenk, Jr., Gene Leynes, Nick Lucius, John Malc, Mark Silverberg, and Peter Schmeideskamp
 Maintainer: "Tom Schenk Jr." <developers@cityofchicago.org>

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -137,7 +137,7 @@ test_that("Warn instead of fail if X-SODA2-* headers are missing", {
   expect_silent(df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.json"))
   expect_equal("data.frame", class(dfCsv), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
   expect_equal("data.frame", class(dfJson), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_equal(150, ncol(dfCsv), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_equal(146, ncol(dfCsv), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
   expect_equal(140, ncol(dfJson), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
 })
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -156,8 +156,8 @@ test_that("Warn instead of fail if X-SODA2-* headers are missing", {
   expect_false(is.null(RSocrata:::getResponse(url_json_complete)$headers[['x-soda2-types']]), info=msg)
   
   ## Check that they return results without warning
-  expect_silent(df <- read.socrata(url_csv_complete), info=msg)
-  expect_silent(df <- read.socrata(url_json_complete), info=msg)
+  expect_silent(df <- read.socrata(url_csv_complete))
+  expect_silent(df <- read.socrata(url_json_complete))
   
 })
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -129,16 +129,34 @@ test_that("read Socrata CSV from New Backend (NBE) endpoint", {
 })
 
 test_that("Warn instead of fail if X-SODA2-* headers are missing", {
-  expect_warning(dfCsv <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.csv?$limit=1000"),
-                info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_warning(dfJson <- read.socrata("https://data.healthcare.gov/resource/enx3-h2qp.json?$limit=1000"),
-                info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_silent(df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.csv"))
-  expect_silent(df <- read.socrata("https://odn.data.socrata.com/resource/pvug-y23y.json"))
-  expect_equal("data.frame", class(dfCsv), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_equal("data.frame", class(dfJson), label="class", info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_equal(146, ncol(dfCsv), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_equal(140, ncol(dfJson), label="columns", info="https://github.com/Chicago/RSocrata/issues/118")
+  
+  ## These data sets are identified in #118 as data sets with missing soda 
+  ## headers. The missing header should cause the data set to return character 
+  ## columns instead of columns cast into their appropriate classes.
+  ## RSocrata should also warn the user when the header is missing.
+  url_csv_missing <- "https://data.healthcare.gov/resource/enx3-h2qp.csv?$limit=1000"
+  url_json_missing <- "https://data.healthcare.gov/resource/enx3-h2qp.json?$limit=1000"
+  ## These URLs should have soda types in the header
+  url_csv_complete <- "https://odn.data.socrata.com/resource/pvug-y23y.csv"
+  url_json_complete <- "https://odn.data.socrata.com/resource/pvug-y23y.json"
+  
+  ## Check that the soda2 headers are missing
+  expect_null(RSocrata:::getResponse(url_csv_missing)$headers[['x-soda2-types']])
+  expect_null(RSocrata:::getResponse(url_json_missing)$headers[['x-soda2-types']])
+  
+  ## Check for warning that the header is missing, which causes the column 
+  ## classes to be returned as character
+  expect_warning(dfCsv <- read.socrata(url_csv), info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_warning(dfJson <- read.socrata(url_json), info="https://github.com/Chicago/RSocrata/issues/118")
+  
+  ## Check that the soda2 headers are present
+  expect_false(is.null(RSocrata:::getResponse(url_csv_complete)$headers[['x-soda2-types']]))
+  expect_false(is.null(RSocrata:::getResponse(url_json_complete)$headers[['x-soda2-types']]))
+  
+  ## Check that they return results without warning
+  expect_silent(df <- read.socrata(url_csv_complete))
+  expect_silent(df <- read.socrata(url_json_complete))
+  
 })
 
 test_that("read Socrata CSV as character", {

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -140,7 +140,7 @@ test_that("Warn instead of fail if X-SODA2-* headers are missing", {
   url_csv_complete <- "https://odn.data.socrata.com/resource/pvug-y23y.csv"
   url_json_complete <- "https://odn.data.socrata.com/resource/pvug-y23y.json"
   
-  msg <- ="https://github.com/Chicago/RSocrata/issues/118"
+  msg <- "https://github.com/Chicago/RSocrata/issues/118"
   
   ## Check that the soda2 headers are missing
   expect_null(RSocrata:::getResponse(url_csv_missing)$headers[['x-soda2-types']], info=msg)

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -140,22 +140,24 @@ test_that("Warn instead of fail if X-SODA2-* headers are missing", {
   url_csv_complete <- "https://odn.data.socrata.com/resource/pvug-y23y.csv"
   url_json_complete <- "https://odn.data.socrata.com/resource/pvug-y23y.json"
   
+  msg <- ="https://github.com/Chicago/RSocrata/issues/118"
+  
   ## Check that the soda2 headers are missing
-  expect_null(RSocrata:::getResponse(url_csv_missing)$headers[['x-soda2-types']])
-  expect_null(RSocrata:::getResponse(url_json_missing)$headers[['x-soda2-types']])
+  expect_null(RSocrata:::getResponse(url_csv_missing)$headers[['x-soda2-types']], info=msg)
+  expect_null(RSocrata:::getResponse(url_json_missing)$headers[['x-soda2-types']], info=msg)
   
   ## Check for warning that the header is missing, which causes the column 
   ## classes to be returned as character
-  expect_warning(dfCsv <- read.socrata(url_csv_missing), info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_warning(dfJson <- read.socrata(url_json_missing), info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_warning(dfCsv <- read.socrata(url_csv_missing), info=msg)
+  expect_warning(dfJson <- read.socrata(url_json_missing), info=msg)
   
   ## Check that the soda2 headers are present
-  expect_false(is.null(RSocrata:::getResponse(url_csv_complete)$headers[['x-soda2-types']]))
-  expect_false(is.null(RSocrata:::getResponse(url_json_complete)$headers[['x-soda2-types']]))
+  expect_false(is.null(RSocrata:::getResponse(url_csv_complete)$headers[['x-soda2-types']]), info=msg)
+  expect_false(is.null(RSocrata:::getResponse(url_json_complete)$headers[['x-soda2-types']]), info=msg)
   
   ## Check that they return results without warning
-  expect_silent(df <- read.socrata(url_csv_complete))
-  expect_silent(df <- read.socrata(url_json_complete))
+  expect_silent(df <- read.socrata(url_csv_complete), info=msg)
+  expect_silent(df <- read.socrata(url_json_complete), info=msg)
   
 })
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -146,8 +146,8 @@ test_that("Warn instead of fail if X-SODA2-* headers are missing", {
   
   ## Check for warning that the header is missing, which causes the column 
   ## classes to be returned as character
-  expect_warning(dfCsv <- read.socrata(url_csv), info="https://github.com/Chicago/RSocrata/issues/118")
-  expect_warning(dfJson <- read.socrata(url_json), info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_warning(dfCsv <- read.socrata(url_csv_missing), info="https://github.com/Chicago/RSocrata/issues/118")
+  expect_warning(dfJson <- read.socrata(url_json_missing), info="https://github.com/Chicago/RSocrata/issues/118")
   
   ## Check that the soda2 headers are present
   expect_false(is.null(RSocrata:::getResponse(url_csv_complete)$headers[['x-soda2-types']]))


### PR DESCRIPTION
Due to a change in an upstream data source, test code had broken. This fixes that code.