### PR TITLE
Fix for Issue 233

### DIFF
--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -153,7 +153,7 @@ fieldName <- function(humanName) {
 #' @export
 #' @author Hugh J. Devlin, Ph. D. \email{Hugh.Devlin@@cityofchicago.org}
 posixify <- function(x) {
-  x <- as.character(x)
+  x <- as.character(toupper(gsub("\\.","",x)))
   if (length(x)==0) return(x)
   
   ## Define regex patterns for short and long date formats (CSV) and ISO 8601 (JSON),  

--- a/R/RSocrata.R
+++ b/R/RSocrata.R
@@ -148,7 +148,7 @@ fieldName <- function(humanName) {
 
 #' Convert Socrata calendar_date string to POSIX
 #'
-#' @param x - character vector in one of two Socrata calendar_date formats
+#' @param x - A character vector containing date-time strings in various formats that will be converted to a POSIX object
 #' @return a POSIX date
 #' @export
 #' @author Hugh J. Devlin, Ph. D. \email{Hugh.Devlin@@cityofchicago.org}


### PR DESCRIPTION
Submitting PR as potential fix for #233.  Two fixes, one as @geneorama suggested to remove periods within %p as this will fix not only macOS but also other locals that use this.  Also, forcing AM/PM to be in upper as some locales default to lower and this would also cause a failure.

And suggested update to param description since the email said it was too vague.